### PR TITLE
avatars for non facebook users are now uniform on all pages. this inc…

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -8,8 +8,8 @@
 
   <div class="col-xs-8 col-xs-offset-2 col-sm-6 col-sm-offset-3 col-md-4 col-md-offset-4">
     <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }, :html=> { class: 'session-form' }) do |f| %>
-      <% avatar_url = current_user.facebook_picture_url || current_user.photo || "http://placehold.it/30x30" %>
-     <%= image_tag avatar_url, class: "avatar-xlarge"%>
+      <% avatar_url = current_user.facebook_picture_url || current_user.photo %>
+        <div class="user-avatar" style="background-image: url('<%= image_path avatar_url %>'); background-size: cover; width: 50px; height:50px; border-radius: 50%; background-position: center;"></div>
     <%= f.error_notification %>
     <div class="form-inputs">
       <%= f.input_field :username, required: false, autofocus: true, label: false, placeholder: "username", class: 'session-input' %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -26,8 +26,11 @@
   <!-- Profile picture and dropdown -->
   <div class="navbar-mustachio-item">
     <div class="dropdown">
-      <% avatar_url = current_user.facebook_picture_url || current_user.photo || "http://placehold.it/30x30" %>
-      <%= image_tag avatar_url, class: "avatar dropdown-toggle", id: "navbar-wagon-menu", "data-toggle" => "dropdown" %>
+
+
+      <% avatar_url = current_user.facebook_picture_url || current_user.photo || "http://placehold.it/30x30"%>
+      <div class="user-avatar dropdown-toggle", data-toggle= "dropdown" style="background-image: url('<%= image_path avatar_url , class: "avatar dropdown-toggle", id: "navbar-wagon-menu" %>'); background-size: cover; width: 50px; height: 50px; border-radius: 50%; background-position: center;"></div>
+
       <ul class="dropdown-menu dropdown-menu-right navbar-mustachio-dropdown-menu">
         <li><%= link_to 'Profile', edit_user_registration_path%></li>
         <li><%= link_to 'Sign out', destroy_user_session_path, method: :delete%></li>


### PR DESCRIPTION
…ludes the device edit page..

User image uploads are square and may not always have a perfect circle shape, for this reason, they often appear as a oval, not a circle.. so I set the image to be the background of a div and made the div into a circle